### PR TITLE
Skip transfer Pure inputs; update workflow ref

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -128,7 +128,7 @@ jobs:
       id-token: write
       contents: write
       actions: read
-    uses: zktx-io/walrus-sites-provenance/.github/workflows/deploy_with_slsa3.yml@a3fbd9ac728f6ce3ed094db290e2bddacbac0ac6 # v0.5.8
+    uses: zktx-io/walrus-sites-provenance/.github/workflows/deploy_with_slsa3.yml@873b86b935c4e3cea7862ad62317f4a3b89b54bc # v0.5.9
     secrets:
       GIT_SIGNER_PIN: ${{ secrets.GIT_SIGNER_PIN }}
       ED25519_PRIVATE_KEY: ${{ secrets.ED25519_PRIVATE_KEY }}

--- a/src/pages/Sign.tsx
+++ b/src/pages/Sign.tsx
@@ -53,6 +53,48 @@ const QUERY_TX_INPUT = `
   }
 `;
 
+interface SignTransactionInput {
+  $kind?: string;
+  Pure?: {
+    bytes: string;
+  };
+}
+
+interface SignTransactionArgument {
+  $kind?: string;
+  Input?: number;
+}
+
+interface SignTransactionCommand {
+  $kind?: string;
+  TransferObjects?: {
+    address?: SignTransactionArgument;
+  };
+}
+
+const inputIndexFromArgument = (
+  argument: SignTransactionArgument | undefined,
+): number | undefined =>
+  argument?.$kind === 'Input' && typeof argument.Input === 'number'
+    ? argument.Input
+    : undefined;
+
+const getTransferRecipientInputIndexes = (
+  commands: SignTransactionCommand[],
+): Set<number> => {
+  const indexes = new Set<number>();
+
+  for (const command of commands) {
+    if (command.$kind !== 'TransferObjects') continue;
+    const inputIndex = inputIndexFromArgument(command.TransferObjects?.address);
+    if (inputIndex !== undefined) {
+      indexes.add(inputIndex);
+    }
+  }
+
+  return indexes;
+};
+
 export const Sign = () => {
   const [searchParams] = useSearchParams();
   const { requestDecryption, pinModal } = usePinPrompt();
@@ -118,7 +160,9 @@ export const Sign = () => {
         ),
       ];
       for (const digest of digests) {
-        if (await isRequestTx(digest)) return digest;
+        if (await isRequestTx(digest)) {
+          return digest;
+        }
       }
     } catch (e) {
       console.error('[grpc][getRequestDigest] error:', e);
@@ -206,6 +250,11 @@ export const Sign = () => {
       // In Sui 2.x, getData() returns inputs and commands directly (no ProgrammableTransaction wrapper).
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const inputs: unknown[] = (txData as any).inputs ?? [];
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const commands: SignTransactionCommand[] = ((txData as any).commands ??
+        []) as SignTransactionCommand[];
+      const transferRecipientInputIndexes =
+        getTransferRecipientInputIndexes(commands);
 
       if (inputs.length === 0) {
         throw new Error('Invalid transaction input structure.');
@@ -225,28 +274,31 @@ export const Sign = () => {
         throw new Error('self signed transaction not allowed');
       }
 
-      // Encrypted chunks are Pure vector<u8> inputs — BCS-encoded (length prefix + data).
-      // The transferObjects recipient address is also stored as a Pure input (32 raw bytes)
-      // but is NOT BCS vector-encoded, so it fails bcs.vector(bcs.u8()).parse() and is excluded.
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const encryptedChunks: Uint8Array[] = (inputs.slice(1) as any[])
-        .filter((input) => {
-          if (input.$kind !== 'Pure') return false;
-          try {
-            bcs.vector(bcs.u8()).parse(fromBase64(input.Pure.bytes));
-            return true;
-          } catch {
-            return false; // address input or unknown — skip
-          }
-        })
-        .map((input) => fromBase64(input.Pure.bytes));
+      // Encrypted chunks are Pure vector<u8> inputs - BCS-encoded (length prefix + data).
+      // TransferObjects recipient addresses are also Pure inputs, so exclude those
+      // by command input index before parsing candidate encrypted chunks.
+      const parsedChunks: Uint8Array[] = [];
+      for (const [relativeIndex, input] of (
+        inputs.slice(1) as SignTransactionInput[]
+      ).entries()) {
+        const inputIndex = relativeIndex + 1;
+        if (input.$kind !== 'Pure' || !input.Pure) continue;
+        if (transferRecipientInputIndexes.has(inputIndex)) {
+          continue;
+        }
 
-      if (encryptedChunks.length < 1) {
+        const pureBytes = fromBase64(input.Pure.bytes);
+        try {
+          const parsed = new Uint8Array(bcs.vector(bcs.u8()).parse(pureBytes));
+          parsedChunks.push(parsed);
+        } catch {
+          // Non-vector Pure inputs are transaction arguments, not encrypted data.
+        }
+      }
+
+      if (parsedChunks.length < 1) {
         throw new Error('Invalid encrypted structure or missing flag.');
       }
-      const parsedChunks: Uint8Array[] = encryptedChunks.map(
-        (chunk) => new Uint8Array(bcs.vector(bcs.u8()).parse(chunk)),
-      );
 
       const totalLength = parsedChunks.reduce(
         (sum, chunk) => sum + chunk.length,
@@ -264,6 +316,7 @@ export const Sign = () => {
         pinRef.current || (await requestDecryption(fullEncrypted));
       pinRef.current = resolvedPin;
       lastKnownDigestRef.current = digest;
+
       const decrypted = await decryptBytes(fullEncrypted, resolvedPin);
       return JSON.parse(new TextDecoder().decode(decrypted)) as Payload;
     } catch (e) {


### PR DESCRIPTION
Update GH workflow reference to a newer commit hash and enhance Sign.tsx parsing for Sui 2.x transactions. Add TypeScript interfaces for transaction inputs/arguments/commands, helper functions (inputIndexFromArgument, getTransferRecipientInputIndexes), and logic to exclude TransferObjects recipient Pure inputs by index before attempting BCS vector parsing. This prevents treating recipient addresses as encrypted chunks, properly parses encrypted vector<u8> inputs, and preserves existing validation/error handling.